### PR TITLE
feat: make navigation responsive

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Home, User, Layout } from "lucide-react";
+import { Home, User, Layout, Menu, X } from "lucide-react";
 import TaxonomySelector from "./TaxonomySelector";
 import { TaxonomyContext } from "../context/TaxonomyContext";
 
 const Navigation: React.FC = () => {
   const location = useLocation();
   const { setTaxonomy } = React.useContext(TaxonomyContext);
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 
   const handleTaxonomyChange = (newTaxonomy: string) => {
     setTaxonomy(newTaxonomy);
@@ -32,7 +33,7 @@ const Navigation: React.FC = () => {
             </Link>
           </div>
 
-          <div className="flex items-center space-x-8">
+          <div className="hidden md:flex md:items-center md:space-x-8">
             {navItems.map(({ path, label, icon: Icon }) => (
               <Link
                 key={path}
@@ -47,16 +48,60 @@ const Navigation: React.FC = () => {
                 {label}
               </Link>
             ))}
+            <TaxonomySelector
+              className="ml-4"
+              onSelectTaxonomy={(selectedTaxonomy) => {
+                console.log("Selected Taxonomy:", selectedTaxonomy);
+                handleTaxonomyChange(selectedTaxonomy);
+              }}
+            />
           </div>
 
-          <TaxonomySelector
-            onSelectTaxonomy={(selectedTaxonomy) => {
-              console.log("Selected Taxonomy:", selectedTaxonomy);
-              handleTaxonomyChange(selectedTaxonomy);
-            }}
-          />
+          <div className="flex items-center md:hidden">
+            <button
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              className="inline-flex items-center justify-center p-2 rounded-md text-gray-700 hover:text-blue-600 hover:bg-gray-50 focus:outline-none"
+            >
+              {isMenuOpen ? (
+                <X className="h-6 w-6" />
+              ) : (
+                <Menu className="h-6 w-6" />
+              )}
+            </button>
+          </div>
         </div>
       </div>
+
+      {isMenuOpen && (
+        <div className="md:hidden border-t border-gray-200">
+          <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+            {navItems.map(({ path, label, icon: Icon }) => (
+              <Link
+                key={path}
+                to={path}
+                className={`block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 ${
+                  location.pathname === path
+                    ? "text-blue-600 bg-blue-50"
+                    : "text-gray-700 hover:text-blue-600 hover:bg-gray-50"
+                }`}
+                onClick={() => setIsMenuOpen(false)}
+              >
+                <Icon className="h-4 w-4 mr-2 inline" />
+                {label}
+              </Link>
+            ))}
+            <div className="mt-3">
+              <TaxonomySelector
+                className="w-full"
+                onSelectTaxonomy={(selectedTaxonomy) => {
+                  console.log("Selected Taxonomy:", selectedTaxonomy);
+                  handleTaxonomyChange(selectedTaxonomy);
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
     </nav>
   );
 };

--- a/src/components/TaxonomySelector.tsx
+++ b/src/components/TaxonomySelector.tsx
@@ -15,8 +15,12 @@ const taxonomyOptions: TaxonomyOption[] = [
 
 interface TaxonomySelectorProps {
   onSelectTaxonomy: (selectedTaxonomy: string) => void;
+  className?: string;
 }
-const TaxonomySelector = ({ onSelectTaxonomy }: TaxonomySelectorProps) => {
+const TaxonomySelector = ({
+  onSelectTaxonomy,
+  className,
+}: TaxonomySelectorProps) => {
   const [selectedTaxonomy, setSelectedTaxonomy] = React.useState("docker");
 
   const handleTaxonomyChange = (
@@ -27,7 +31,11 @@ const TaxonomySelector = ({ onSelectTaxonomy }: TaxonomySelectorProps) => {
   };
 
   return (
-    <select value={selectedTaxonomy} onChange={handleTaxonomyChange}>
+    <select
+      value={selectedTaxonomy}
+      onChange={handleTaxonomyChange}
+      className={`p-2 border rounded-md ${className ?? ""}`}
+    >
       {taxonomyOptions.map((option) => (
         <option key={option.value} value={option.value}>
           {option.label}


### PR DESCRIPTION
## Summary
- add mobile-friendly navigation with collapsible menu
- allow taxonomy selector to accept styling and fit mobile layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b665f64f48327a024af4957a324bc